### PR TITLE
Replace deprecated pkg_resources usage with importlib APIs

### DIFF
--- a/idmefv2/message.py
+++ b/idmefv2/message.py
@@ -3,7 +3,9 @@
 
 import json
 import jsonschema
-from pkg_resources import resource_stream
+# from pkg_resources import resource_stream
+from importlib.resources import files
+
 
 from .serializer import get_serializer
 
@@ -54,11 +56,10 @@ class Message(dict):
 
     def validate(self) -> None:
         schema_file = self._VERSIONS.get(self.get('Version'), self._VERSIONS[None])
-        stream = resource_stream('idmefv2.schemas', schema_file)
-        try:
+        schema_path = files("idmefv2.schemas").joinpath(schema_file)
+    
+        with schema_path.open("r", encoding="utf-8") as stream:
             jsonschema.validate(self, json.load(stream))
-        finally:
-            stream.close()
 
     def serialize(self, content_type: str) -> SerializedMessage:
         serializer = get_serializer(content_type)

--- a/idmefv2/serializer.py
+++ b/idmefv2/serializer.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import abc
-import pkg_resources
+from importlib.metadata import entry_points
 import warnings
 
 from collections.abc import Callable
@@ -53,11 +53,11 @@ def get_serializer(content_type: str) -> 'Serializer':
 
     if _serializers is None:
         _serializers = {}
-        for entry_point in pkg_resources.iter_entry_points('idmefv2.serializer'):
+        for ep in entry_points(group='idmefv2.serializer'):
             try:
-                cls = entry_point.load()
+                cls = ep.load()
                 if issubclass(cls, Serializer):
-                    _serializers[entry_point.name] = cls
+                    _serializers[ep.name] = cls
             except Exception as e:
                 warnings.warn(str(e), ResourceWarning)
 


### PR DESCRIPTION
Hello, we are depending on IDMEFv2 for reporting the evidence and alerts of our IDPS [Slips](https://github.com/stratosphereips/StratosphereLinuxIPS)

IDMEF has been throwing this depraction warning for a while
![Screenshot_20251101_091657](https://github.com/user-attachments/assets/d243d4ae-de1e-4d4b-b10c-4795347c71e3)

so this PR is a small fix to stop getting that error. fixes https://github.com/SECEF/python-idmefv2/issues/2  :)!

